### PR TITLE
Task 3: Mine Placement Logic

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -9,12 +9,12 @@
             "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
             "elm/html": "1.0.0",
+            "elm/random": "1.0.0",
             "elm-explorations/test": "2.2.0"
         },
         "indirect": {
             "elm/bytes": "1.0.8",
             "elm/json": "1.1.3",
-            "elm/random": "1.0.0",
             "elm/time": "1.0.0",
             "elm/url": "1.0.0",
             "elm/virtual-dom": "1.0.4"

--- a/src/Board.elm
+++ b/src/Board.elm
@@ -1,8 +1,10 @@
-module Board exposing (Board, empty, view)
+module Board exposing (Board, empty, view, withMines)
 
+import Array
 import Cell exposing (Cell, Position)
 import Html exposing (Html, div)
 import Html.Attributes exposing (style)
+import Random
 
 
 type alias Board =
@@ -21,7 +23,7 @@ empty rows cols =
 
 view : (Position -> msg) -> Board -> Html msg
 view onCellClick board =
-    div 
+    div
         [ style "display" "grid"
         , style "grid-template-columns" "repeat(9, 30px)"
         , style "gap" "1px"
@@ -35,3 +37,91 @@ view onCellClick board =
 viewRow : (Position -> msg) -> List Cell -> List (Html msg)
 viewRow onCellClick cells =
     List.map (Cell.view onCellClick) cells
+
+
+withMines : Int -> Int -> Int -> Random.Seed -> Board
+withMines rows cols mineCount seed =
+    let
+        totalCells =
+            rows * cols
+
+        positions =
+            generateAllPositions rows cols
+
+        ( minePositions, _ ) =
+            Random.step (selectRandomPositions mineCount positions) seed
+    in
+    empty rows cols
+        |> placeMines minePositions
+
+
+generateAllPositions : Int -> Int -> List Position
+generateAllPositions rows cols =
+    List.range 0 (rows - 1)
+        |> List.concatMap
+            (\row ->
+                List.range 0 (cols - 1)
+                    |> List.map (\col -> { row = row, col = col })
+            )
+
+
+selectRandomPositions : Int -> List Position -> Random.Generator (List Position)
+selectRandomPositions count positions =
+    Random.map (List.take count) (shuffleList positions)
+
+
+shuffleList : List a -> Random.Generator (List a)
+shuffleList list =
+    list
+        |> Array.fromList
+        |> shuffleArray
+        |> Random.map Array.toList
+
+
+shuffleArray : Array.Array a -> Random.Generator (Array.Array a)
+shuffleArray array =
+    let
+        length =
+            Array.length array
+    in
+    shuffleArrayHelper (length - 1) array
+
+
+shuffleArrayHelper : Int -> Array.Array a -> Random.Generator (Array.Array a)
+shuffleArrayHelper i array =
+    if i <= 0 then
+        Random.constant array
+
+    else
+        Random.int 0 i
+            |> Random.andThen
+                (\j ->
+                    case ( Array.get i array, Array.get j array ) of
+                        ( Just a, Just b ) ->
+                            array
+                                |> Array.set i b
+                                |> Array.set j a
+                                |> shuffleArrayHelper (i - 1)
+
+                        _ ->
+                            shuffleArrayHelper (i - 1) array
+                )
+
+
+placeMines : List Position -> Board -> Board
+placeMines minePositions board =
+    List.map (placeMinesInRow minePositions) board
+
+
+placeMinesInRow : List Position -> List Cell -> List Cell
+placeMinesInRow minePositions cells =
+    List.map (placeMineInCell minePositions) cells
+
+
+placeMineInCell : List Position -> Cell -> Cell
+placeMineInCell minePositions cell =
+    if List.any (\pos -> pos.row == cell.position.row && pos.col == cell.position.col) minePositions then
+        { cell | isMine = True }
+
+    else
+        cell

--- a/src/Cell.elm
+++ b/src/Cell.elm
@@ -19,6 +19,7 @@ type State
 type alias Cell =
     { position : Position
     , state : State
+    , isMine : Bool
     }
 
 
@@ -26,6 +27,7 @@ create : Int -> Int -> Cell
 create row col =
     { position = { row = row, col = col }
     , state = Hidden
+    , isMine = False
     }
 
 
@@ -43,14 +45,22 @@ view onCellClick cell =
         , style "user-select" "none"
         , onClick (onCellClick cell.position)
         ]
-        [ text (stateToString cell.state) ]
+        [ text (cellToString cell) ]
 
 
-stateToString : State -> String
-stateToString state =
-    case state of
+cellToString : Cell -> String
+cellToString cell =
+    case cell.state of
         Hidden ->
-            ""
+            if cell.isMine then
+                "💣"
+
+            else
+                ""
 
         Revealed ->
-            "R"
+            if cell.isMine then
+                "💣"
+
+            else
+                "R"

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -4,6 +4,7 @@ import Board
 import Browser
 import Cell exposing (Position)
 import Html exposing (Html, div, h1, text)
+import Random
 
 
 main : Program () Model Msg
@@ -27,7 +28,14 @@ type Msg
 
 init : () -> ( Model, Cmd Msg )
 init _ =
-    ( { board = Board.empty 9 9 }, Cmd.none )
+    let
+        seed =
+            Random.initialSeed 42
+
+        board =
+            Board.withMines 9 9 10 seed
+    in
+    ( { board = board }, Cmd.none )
 
 
 update : Msg -> Model -> ( Model, Cmd Msg )

--- a/tests/BoardTest.elm
+++ b/tests/BoardTest.elm
@@ -3,6 +3,7 @@ module BoardTest exposing (..)
 import Board
 import Cell exposing (Position, State(..))
 import Expect exposing (Expectation)
+import Random
 import Test exposing (..)
 
 
@@ -13,7 +14,8 @@ suite =
             [ test "creates a 9x9 board" <|
                 \_ ->
                     let
-                        board = Board.empty 9 9
+                        board =
+                            Board.empty 9 9
                     in
                     board
                         |> List.length
@@ -21,8 +23,11 @@ suite =
             , test "each row has 9 cells" <|
                 \_ ->
                     let
-                        board = Board.empty 9 9
-                        firstRow = List.head board |> Maybe.withDefault []
+                        board =
+                            Board.empty 9 9
+
+                        firstRow =
+                            List.head board |> Maybe.withDefault []
                     in
                     firstRow
                         |> List.length
@@ -30,20 +35,142 @@ suite =
             , test "cells have correct positions" <|
                 \_ ->
                     let
-                        board = Board.empty 3 3
-                        firstRow = List.head board |> Maybe.withDefault []
-                        firstCell = List.head firstRow |> Maybe.withDefault (Cell.create 0 0)
+                        board =
+                            Board.empty 3 3
+
+                        firstRow =
+                            List.head board |> Maybe.withDefault []
+
+                        firstCell =
+                            List.head firstRow |> Maybe.withDefault (Cell.create 0 0)
                     in
                     firstCell.position
                         |> Expect.equal { row = 0, col = 0 }
             , test "all cells start as Hidden" <|
                 \_ ->
                     let
-                        board = Board.empty 2 2
-                        firstRow = List.head board |> Maybe.withDefault []
-                        firstCell = List.head firstRow |> Maybe.withDefault (Cell.create 0 0)
+                        board =
+                            Board.empty 2 2
+
+                        firstRow =
+                            List.head board |> Maybe.withDefault []
+
+                        firstCell =
+                            List.head firstRow |> Maybe.withDefault (Cell.create 0 0)
                     in
                     firstCell.state
                         |> Expect.equal Hidden
             ]
+        , describe "withMines"
+            [ test "creates board with correct mine count" <|
+                \_ ->
+                    let
+                        seed =
+                            Random.initialSeed 42
+
+                        board =
+                            Board.withMines 9 9 10 seed
+
+                        mineCount =
+                            countMines board
+                    in
+                    mineCount
+                        |> Expect.equal 10
+            , test "deterministic mine placement with same seed" <|
+                \_ ->
+                    let
+                        seed =
+                            Random.initialSeed 123
+
+                        board1 =
+                            Board.withMines 9 9 10 seed
+
+                        board2 =
+                            Board.withMines 9 9 10 seed
+
+                        mines1 =
+                            getMinePositions board1
+
+                        mines2 =
+                            getMinePositions board2
+                    in
+                    mines1
+                        |> Expect.equal mines2
+            , test "different seeds produce different mine placements" <|
+                \_ ->
+                    let
+                        seed1 =
+                            Random.initialSeed 1
+
+                        seed2 =
+                            Random.initialSeed 2
+
+                        board1 =
+                            Board.withMines 9 9 10 seed1
+
+                        board2 =
+                            Board.withMines 9 9 10 seed2
+
+                        mines1 =
+                            getMinePositions board1
+
+                        mines2 =
+                            getMinePositions board2
+                    in
+                    mines1
+                        |> Expect.notEqual mines2
+            , test "mine count never exceeds board size" <|
+                \_ ->
+                    let
+                        seed =
+                            Random.initialSeed 999
+
+                        board =
+                            Board.withMines 3 3 5 seed
+
+                        mineCount =
+                            countMines board
+                    in
+                    mineCount
+                        |> Expect.equal 5
+            , test "all cells without mines have isMine = False" <|
+                \_ ->
+                    let
+                        seed =
+                            Random.initialSeed 42
+
+                        board =
+                            Board.withMines 3 3 2 seed
+
+                        nonMineCount =
+                            countNonMines board
+                    in
+                    nonMineCount
+                        |> Expect.equal 7
+            ]
         ]
+
+
+countMines : Board.Board -> Int
+countMines board =
+    board
+        |> List.concat
+        |> List.filter .isMine
+        |> List.length
+
+
+countNonMines : Board.Board -> Int
+countNonMines board =
+    board
+        |> List.concat
+        |> List.filter (\cell -> not cell.isMine)
+        |> List.length
+
+
+getMinePositions : Board.Board -> List Position
+getMinePositions board =
+    board
+        |> List.concat
+        |> List.filter .isMine
+        |> List.map .position
+        |> List.sortBy (\pos -> pos.row * 1000 + pos.col)


### PR DESCRIPTION
## Summary
- Add mine field to Cell type with isMine boolean
- Implement random mine placement using Fisher-Yates shuffle algorithm
- Add deterministic seed support for reproducible mine generation
- Ensure correct mine count (10 mines for 9x9 board)
- Add comprehensive test coverage for mine placement logic
- Display mines visually with 💣 emoji for verification

## Test plan
- [x] All existing tests pass
- [x] New mine placement tests verify correct mine count
- [x] Deterministic seed produces same mine placement
- [x] Different seeds produce different mine placements
- [x] Visual verification shows exactly 10 mines on board
- [x] Build and linting checks pass

Closes #6

🍀 Generated with [Claude Code](https://claude.ai/code)